### PR TITLE
Redirect stdout and stderror for rclone service files

### DIFF
--- a/MergerFS-Rclone/Service Files/rclone-normal.service
+++ b/MergerFS-Rclone/Service Files/rclone-normal.service
@@ -12,6 +12,8 @@ ExecStart=/homexx/yyyyy/bin/rclone mount remote: /homexx/yyyyy/Stuff/Mount \
   --user-agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36' \
   --config /homexx/yyyyy/.config/rclone/rclone.conf \
   --use-mmap
+
+StandardOutput=file:/homexx/yyyyy/scripts/rclone_mount.log
 ExecStop=/bin/fusermount -uz /homexx/yyyyy/Stuff/Mount
 Restart=on-failure
 

--- a/MergerFS-Rclone/Service Files/rclone-vfs.service
+++ b/MergerFS-Rclone/Service Files/rclone-vfs.service
@@ -20,6 +20,8 @@ ExecStart=/homexx/yyyyy/bin/rclone mount gdrive: /homexx/yyyyy/Stuff/Mount \
   --vfs-read-chunk-size 64M \
   --vfs-read-chunk-size-limit 2048M \
   --tpslimit 10
+
+StandardOutput=file:/homexx/yyyyy/scripts/rclone_vfs_mount.log
 ExecStop=/bin/fusermount -uz /homexx/yyyyy/Stuff/Mount
 Restart=on-failure
 

--- a/MergerFS-Rclone/Upload Scripts/rclone-uploader.service
+++ b/MergerFS-Rclone/Upload Scripts/rclone-uploader.service
@@ -17,8 +17,9 @@ ExecStart=/homexx/yyyyy/bin/rclone move /homexx/yyyyy/Stuff/Local/ gdrive: \
     --use-mmap \
     --transfers=2 \
     --checkers=4 \
-    --drive-stop-on-upload-limit \
-    --log-file /homexx/yyyyy/scripts/rclone-uploader.log
+    --drive-stop-on-upload-limit
+
+StandardOutput=file:/homexx/yyyyy/scripts/rclone_uploader.log
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Allows non root USB customers to check a log file to see why their mount fails to start.

Did not use rclones built in log file as that cannot always be trusted to be written to if something goes wrong in the initial stages.