### PR TITLE
Removed flag --fast-list

### DIFF
--- a/MergerFS-Rclone/Upload Scripts/rclone-upload-with-notification.sh
+++ b/MergerFS-Rclone/Upload Scripts/rclone-upload-with-notification.sh
@@ -34,7 +34,6 @@ else
       --drive-chunk-size 64M \
       --use-mmap \
       --delete-empty-src-dirs \
-      --fast-list \
       --log-file="$LOG_FILE" \
       --stats=9999m \
       --tpslimit=5 \

--- a/MergerFS-Rclone/Upload Scripts/rclone-upload.sh
+++ b/MergerFS-Rclone/Upload Scripts/rclone-upload.sh
@@ -17,7 +17,6 @@ else
         -vvv \
         --drive-stop-on-upload-limit \
         --delete-empty-src-dirs \
-        --fast-list \
         --bwlimit=8M \
         --use-mmap \
         --transfers=2 \

--- a/MergerFS-Rclone/Upload Scripts/rclone-uploader.service
+++ b/MergerFS-Rclone/Upload Scripts/rclone-uploader.service
@@ -10,7 +10,6 @@ ExecStart=%h/bin/rclone move %h/Stuff/Local/ remote: \
     --tpslimit 5 \
     -vvv \
     --delete-empty-src-dirs \
-    --fast-list \
     --bwlimit=8M \
     --use-mmap \
     --transfers=2 \


### PR DESCRIPTION
--fast-list has been removed because it can cause issues for clients that have a large number of files/directories in their cloud drive.