### PR TITLE
Use SCP002's fork of xTeVe

### DIFF
--- a/xTeVe/xteve-install.sh
+++ b/xTeVe/xteve-install.sh
@@ -16,8 +16,7 @@ mkdir -p "$HOME"/.xteve-tmp
 
 # xTeve Extract
 cd "$HOME"/.xteve-tmp || exit
-wget https://github.com/xteve-project/xTeVe-Downloads/raw/master/xteve_linux_amd64.zip
-unzip xteve_linux_amd64.zip -d "$HOME"/bin/
+wget https://github.com/SCP002/xTeVe/releases/latest/download/xteve_linux_amd64 -O "$HOME/bin/xteve"
 
 # Unused Port Picker
 app-ports show


### PR DESCRIPTION
Since the main project is no longer maintained (last commit was in May 2021) I suggest changing to SCP002's fork that contains the latest and greatest xTeVe binaries.

Discussion of maintainer ownership is discussed here: https://github.com/xteve-project/xTeVe/issues/320