### PR TITLE
Update xteve-install.sh to support multiple xteve instances

### DIFF
--- a/xTeVe/xteve-install.sh
+++ b/xTeVe/xteve-install.sh
@@ -4,6 +4,7 @@
 # Installs XTeVe Locally in USB Slot
 
 printf "\033[0;31mDisclaimer: This installer is unofficial and USB staff will not support any issues with it\033[0m\n"
+echo "To install multiple intances rerun with unique id, Ex: $0 <ID>"
 read -p "Type confirm if you wish to continue: " input
 if [ ! "$input" = "confirm" ]
 then
@@ -31,6 +32,15 @@ read -r appname
 proper_app_name=$(app-ports show | grep -i "$appname" | cut -c 7-)
 port=$(app-ports show | grep -i "$appname" | cut -b -5)
 
+if [ -n "$1" ]
+then
+     id=$1
+else
+     id=""
+fi
+
+config_dir="$HOME/.xteve$id"
+
 echo "Are you sure you want to use $proper_app_name's port? type 'confirm' to proceed."
 read -r input
 if [ ! "$input" = "confirm" ]
@@ -39,10 +49,10 @@ then
 fi
 
 # Generate config
-timeout 10  "$HOME"/bin/xteve -port="$port"
+timeout 10  "$HOME"/bin/xteve -port="$port" -config "$config_dir/"
 
 # Set tmp
-sed -i "s|/tmp/xteve|/tmp/$USER/xteve|g" "$HOME"/.xteve/settings.json
+sed -i "s|/tmp/xteve|/tmp/$USER/xteve|g" $config_dir/settings.json
 
 # systemd service
 export XDG_RUNTIME_DIR=/run/user/"$UID"
@@ -52,15 +62,15 @@ Description=xTeve Tuner
 [Service]
 Type=simple
 
-ExecStart=$HOME/bin/xteve -port=$port
+ExecStart=$HOME/bin/xteve -port=$port -config $config_dir/
 
 [Install]
-WantedBy=default.target" > "$HOME/.config/systemd/user/xteve.service"
+WantedBy=default.target" > "$HOME/.config/systemd/user/xteve$id.service"
 
 # Start Services
 systemctl --user daemon-reload
-systemctl --user start xteve.service
-systemctl --user enable xteve.service
+systemctl --user start xteve$id.service
+systemctl --user enable xteve$id.service
 
 echo ""
 echo ""


### PR DESCRIPTION
Seedbox Plex has the ability to add multiple xteve instances but script doesn't

this PR should fix it to install with another instance id. For example:  ./xteve-install.sh 2